### PR TITLE
Comment and fix GetMode()/ Show controls for no surveys in manual mode.

### DIFF
--- a/adminsettings.php
+++ b/adminsettings.php
@@ -103,9 +103,9 @@ if (has_capability('moodle/site:config', context_system::instance())) {
                 $newvaluemodename = 'category_mode_' . $allocation->get('id');
                 // Checkboxex only get submitted if they're checked.
                 if (isset($data->$newvaluemodename) && $data->$newvaluemodename) {
-                    $newvaluemode = 1;
+                    $newvaluemode = 1; // Category uses automated mode.
                 } else {
-                    $newvaluemode = 0;
+                    $newvaluemode = 0; // Category uses manual mode.
                 }
                 try {
                     $oldvaluemode = $allocation->get('category_mode');

--- a/block_evasys_sync.php
+++ b/block_evasys_sync.php
@@ -75,11 +75,11 @@ class block_evasys_sync extends block_base{
                 return $this->content;
             }
 
-            if (!$mode) {
-                $href = new moodle_url('/blocks/evasys_sync/sync.php');
-            } else {
+            if ($ismodeautomated) {
                 $href = new moodle_url('/course/view.php',
-                                       array('id' => $this->page->course->id, "evasyssynccheck" => true));
+                    array('id' => $this->page->course->id, "evasyssynccheck" => true));
+            } else {
+                $href = new moodle_url('/blocks/evasys_sync/sync.php');
             }
 
             // Get Status.

--- a/block_evasys_sync.php
+++ b/block_evasys_sync.php
@@ -61,9 +61,9 @@ class block_evasys_sync extends block_base{
         }
 
         if ($evasyssynccheck === 1) {
-            $mode = (bool) \block_evasys_sync\evasys_inviter::getmode($this->page->course->category);
+            $ismodeautomated = (bool) \block_evasys_sync\evasys_inviter::getmode($this->page->course->category);
             // If the teacher can start the evaluation directly, we'll want to run some javascript initialization.
-            if ($mode) {
+            if ($ismodeautomated) {
                 $this->page->requires->js_call_amd('block_evasys_sync/invite_manager', 'init');
             }
             $evasyssynchronizer = new \block_evasys_sync\evasys_synchronizer($this->page->course->id);
@@ -108,7 +108,7 @@ class block_evasys_sync extends block_base{
                 'href' => $href,
                 'sesskey' => sesskey(),
                 'courseid' => $this->page->course->id,
-                'direct' => $mode,
+                'direct' => $ismodeautomated,
                 'startdisabled' => $startdisabled,
                 'enddisabled' => $enddisabled,
                 'startoption' => $enddisabled xor $startdisabled,

--- a/block_evasys_sync.php
+++ b/block_evasys_sync.php
@@ -116,7 +116,7 @@ class block_evasys_sync extends block_base{
                 'nostudents' => $nostudents
             );
             $courses = array();
-            $showcontrols = false;
+            $hassurveys = false;
             foreach ($evasyscourses as $evasyscourseinfo) {
                 $course = array();
                 $course['evasyscoursetitle'] = $evasyssynchronizer->get_course_name($evasyscourseinfo['id']);
@@ -142,13 +142,18 @@ class block_evasys_sync extends block_base{
                     }
 
                     $surveys[] = $survey;
-                    $showcontrols = true;
+                    $hassurveys = true;
                 }
                 $course['surveys'] = $surveys;
                 $courses[] = $course;
             }
             $data['courses'] = $courses;
-            $data['showcontrols'] = $showcontrols;
+
+            /* In case of the manual workflow, we can start synchronisation also, if no surveys are registered, yet.
+             * In case of the automated workflow, we require surveys
+             * in order to be able to automatically trigger the evaluation. */
+            $data['showcontrols'] = $hassurveys || !$ismodeautomated;
+
             $this->content->text .= $OUTPUT->render_from_template("block_evasys_sync/block", $data);
         } else {
             $hasextras = \block_evasys_sync\course_evasys_courses_allocation::record_exists_select("course = {$this->page->course->id} AND NOT evasyscourses = ''");

--- a/classes/evasys_inviter.php
+++ b/classes/evasys_inviter.php
@@ -304,10 +304,12 @@ class evasys_inviter {
     }
 
     /**
+     * Determines if the workflow used by the course category is automated or manual.
+     * If true, the category uses the automated mode. If false, the workflow is manual.
      * @param $category
      * @return bool wether the teacher may set dates for this survey himself.
-     * @throws dml_exception
-     * @throws moodle_exception
+     * @throws \dml_exception
+     * @throws \moodle_exception
      */
     public static function getmode($category) {
         global $DB;

--- a/classes/evasys_inviter.php
+++ b/classes/evasys_inviter.php
@@ -314,13 +314,13 @@ class evasys_inviter {
     public static function getmode($category) {
         global $DB;
         $mode = $DB->get_record('block_evasys_sync_categories', array('course_category' => $category));
-        if ($mode) {
+        if ($mode !== false) {
             return (bool) $mode->category_mode;
         } else {
             $parents = \core_course_category::get($category)->get_parents();
             for ($i = count($parents) - 1; $i >= 0; $i--) {
                 $mode = $DB->get_record('block_evasys_sync_categories', array('course_category' => $parents[$i]));
-                if ($mode) {
+                if ($mode !== false) {
                     return (bool) $mode->category_mode;
                 }
             }


### PR DESCRIPTION
So far the function getmode and everything, which had to do with the category_mode was badly commented so that it was very difficult to determine the meaning of getMode returning true or false.
I added some comments describing this. Also I fixed the bug, in which a manual category mode was never read from the DB.
Further, the controls are now also shown in manual mode if the course has no surveys defined. This was also the procedure before the mustache changes.