### PR TITLE
Fix timezone display

### DIFF
--- a/classes/evasys_synchronizer.php
+++ b/classes/evasys_synchronizer.php
@@ -303,9 +303,9 @@ class evasys_synchronizer {
             "hinzugefügt oder der Zeitraum angepasst. Dies ist ggf. unten angegeben.\r\n\r\n";
 
         $startdate = new \DateTime('@' . $dates["start"], \core_date::get_server_timezone_object());
-        $formattedstartdate = $startdate->format('d.m.Y H:i:s');
+        $formattedstartdate = userdate($startdate->getTimestamp(), get_string('strftimedatetimeshort', 'langconfig'));
         $enddate = new \DateTime('@' . $dates["end"], \core_date::get_server_timezone_object());
-        $formattedenddate = $enddate->format('d.m.Y H:i:s');
+        $formattedenddate = userdate($enddate->getTimestamp(), get_string('strftimedatetimeshort', 'langconfig'));
 
         $notiftext .= "Gewünschter Evaluationszeitraum: " . $formattedstartdate . " bis " .
             $formattedenddate . $textdatechanged . "\r\n\r\n";


### PR DESCRIPTION
A user has reported that the starting/ending times displayed in the email request are exactly 2 hours before the intended time. Definitely a timezone issue.

Using `userdate` fixes the issue. Already tested in live_image.