### PR TITLE
Disable of evasyssubmit button in case of enddisabled

### DIFF
--- a/templates/block.mustache
+++ b/templates/block.mustache
@@ -74,10 +74,10 @@ Example context (json):
             {{/block_evasys_sync/datetimepicker}}
         </fieldset>
         {{^direct}}
-            <input id='evasyssubmitbutton' class="in_box_button" type="submit" value="{{# str}}invitestudents, block_evasys_sync{{/str}}" {{enddisabled}}/>
+            <input id='evasyssubmitbutton' class="in_box_button" type="submit" value="{{# str}}invitestudents, block_evasys_sync{{/str}}" {{#enddisabled}}disabled{{/enddisabled}}/>
         {{/direct}}
         {{#direct}}
-            <input id='evasyssubmitbutton' class="in_box_button" type="submit" value="{{# str}}planorstartevaluation, block_evasys_sync{{/str}}" {{enddisabled}}/>
+            <input id='evasyssubmitbutton' class="in_box_button" type="submit" value="{{# str}}planorstartevaluation, block_evasys_sync{{/str}}" {{#enddisabled}}disabled{{/enddisabled}}/>
         {{/direct}}
     {{/showcontrols}}
 </form>


### PR DESCRIPTION
When the enddisabled fieled changed from type string to bool, two places were missed in the template.