### PR TITLE
make sending a confirmation email for requested evaluations to teachers optional

### DIFF
--- a/classes/evaluation_manager.php
+++ b/classes/evaluation_manager.php
@@ -109,11 +109,13 @@ class evaluation_manager {
             $data->courseshort = $course->shortname;
             $data->coursefull = $course->fullname;
 
-            foreach ($teachers as $teacher) {
-                email_to_user($teacher, $coordinatoruser,
+            if ($category->send_mail_to_teacher()) {
+                foreach ($teachers as $teacher) {
+                    email_to_user($teacher, $coordinatoruser,
                         get_string('notify_teacher_email_subject', 'block_evasys_sync', $data),
                         get_string('notify_teacher_email_body', 'block_evasys_sync', $data)
-                );
+                    );
+                }
             }
 
             self::clear_error($course->id);

--- a/classes/evasys_category.php
+++ b/classes/evasys_category.php
@@ -43,6 +43,7 @@ class evasys_category extends persistent {
     const MASK_AUTOMATIC_TASK_CREATION = 1 << 2;
     const MASK_TEACHER_CAN_CHANGE_EVALUATION  = 1 << 3;
     const MASK_EVALUATION_CHANGE_NEEDS_APPROVAL = 1 << 4;
+    const MASK_SEND_MAIL_TO_TEACHER = 1 << 5;
 
     /**
      * Return the definition of the properties of this model.
@@ -117,6 +118,10 @@ class evasys_category extends persistent {
 
     public function can_teacher_request_evaluation() : bool {
         return $this->get('mode_flags') & self::MASK_TEACHER_CAN_REQUEST_EVALUATION;
+    }
+
+    public function send_mail_to_teacher() : bool {
+        return $this->get('mode_flags') & self::MASK_SEND_MAIL_TO_TEACHER;
     }
 
     public function teacher_evaluation_request_needs_approval() : bool {

--- a/classes/local/form/evasys_category_edit_form.php
+++ b/classes/local/form/evasys_category_edit_form.php
@@ -69,6 +69,10 @@ class evasys_category_edit_form extends moodleform {
                 get_string('teacher_can_request_evaluation', 'block_evasys_sync'));
         $mform->setDefault('teacher_can_request_evaluation', true);
 
+        $mform->addElement('checkbox', 'send_mail_to_teacher',
+                get_string('send_mail_to_teacher', 'block_evasys_sync'));
+        $mform->setDefault('send_mail_to_teacher', true);
+
         // TODO automatic
         /*$mform->addElement('checkbox', 'teacher_evaluation_request_needs_approval',
                 get_string('teacher_evaluation_request_needs_approval', 'block_evasys_sync'));
@@ -91,6 +95,7 @@ class evasys_category_edit_form extends moodleform {
             $mform->setDefault('standard_time_end', $this->evasys_category->get('standard_time_end'));
         }
         $mform->setDefault('teacher_can_request_evaluation', $this->evasys_category->can_teacher_request_evaluation());
+        $mform->setDefault('send_mail_to_teacher', $this->evasys_category->send_mail_to_teacher());
         // $mform->setDefault('teacher_evaluation_request_needs_approval', $this->evasys_category->teacher_evaluation_request_needs_approval());
         // $mform->setDefault('automatic_task_creation', $this->evasys_category->is_automatic());
 
@@ -108,6 +113,9 @@ class evasys_category_edit_form extends moodleform {
         $flags = 0;
         if ($data->teacher_can_request_evaluation ?? false) {
             $flags |= evasys_category::MASK_TEACHER_CAN_REQUEST_EVALUATION;
+        }
+        if ($data->send_mail_to_teacher ?? false) {
+            $flags |= evasys_category::MASK_SEND_MAIL_TO_TEACHER;
         }
         if ($data->teacher_evaluation_needs_approval ?? false) {
             $flags |= evasys_category::MASK_EVALUATION_REQUEST_NEEDS_APPROVAL;

--- a/lang/de/block_evasys_sync.php
+++ b/lang/de/block_evasys_sync.php
@@ -245,6 +245,8 @@ $string['automatic_task_creation'] = 'Geplante Vorgänge werden automatisch in E
 $string['teacher_can_change_evaluation'] = 'Lehrende können bestehende Evaluationen verändern';
 $string['teacher_evaluation_change_needs_approval'] = 'Änderungen an bestehenden Evaluationen müssen von Ihnen bestätigt werden';
 
+$string['send_mail_to_teacher'] = 'Sende Bestätigungsmail an Lehrende';
+
 $string['search_for_courses'] = 'Nach Kursen suchen';
 
 $string['evasys_settings_for'] = 'Evasys-Einstellungen für {$a}';

--- a/lang/en/block_evasys_sync.php
+++ b/lang/en/block_evasys_sync.php
@@ -256,6 +256,8 @@ $string['automatic_task_creation'] = 'Planned tasks are created automatically in
 $string['teacher_can_change_evaluation'] = 'Teachers can change existing evaluation';
 $string['teacher_evaluation_change_needs_approval'] = 'Teacher\'s evaluation changes needs approval from you';
 
+$string['send_mail_to_teacher'] = 'Send mail to teacher';
+
 $string['search_for_courses'] = 'Search for courses';
 
 $string['evasys_settings_for'] = 'Evasys settings for {$a}';


### PR DESCRIPTION
Evasys-managers can know choose wether to have an email sent to teachers of the course of which they started an evaluation on